### PR TITLE
fix: askpass() not working with radian console

### DIFF
--- a/R/onload.R
+++ b/R/onload.R
@@ -6,6 +6,9 @@ setup_askpass_vars <- function(){
   if(var_exists('RSTUDIO')){
     fix_rstudio_path()
   } else {
+    if(var_exists('RADIAN_VERSION')){
+      options(askpass = ask_password_default)
+    }
     # This is mostly for RGui and R.app (tty could mean MacOS server)
     if(is_windows() || (is_macos() && !isatty(stdin()))){
       askpass_bin = ssh_askpass()


### PR DESCRIPTION
I am trying to fix issue #6 
In radian console, for some reason I could not understand, the following code returns a Python object rather than NULL.

```r
library(askpass)
getOptions("askpass")
```
This causes `askpass()` to fail when used in radian.

As a workaround, I detect radian the same way you use to detect RSTUDIO and I force the correct value for the option.